### PR TITLE
fix(assets/init): force config.yml symlink to restart existing instances.

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -31,7 +31,7 @@ update-ca-certificates --fresh >/dev/null 2>&1
 appStart () {
 	echo "Starting gitlab-ci-runner..."
 
-	sudo -u gitlab_ci_runner -H ln -s /home/gitlab_ci_runner/data/config.yml config.yml
+	sudo -u gitlab_ci_runner -H ln -sf /home/gitlab_ci_runner/data/config.yml config.yml
 	bundle exec ./bin/runner
 }
 


### PR DESCRIPTION
My runner instances don't survive a clean restart of the host. Docker (with the autostart feature) tries to start the instances but they immediately exit.

``` sh
root@si-gitlab:~# docker ps -a
CONTAINER ID        IMAGE                               COMMAND               CREATED             STATUS                      PORTS                                   NAMES
81e85e03a30c        sameersbn/gitlab-ci-runner:latest   /app/init app:start   39 minutes ago      Exited (1) 9 minutes ago                                            gitlab-ci-runner-3                
```

The reason can be found in the log: `failed to create symbolic link 'config.yml': File exists` (the init script runs with `set -e` so it will abort at this point).

This tiny PR should fix the problem.
